### PR TITLE
Revert-update for stable 1.21

### DIFF
--- a/tweak_vest/config.cpp
+++ b/tweak_vest/config.cpp
@@ -10,9 +10,9 @@ class CfgPatches
 };
 class CfgVehicles
 {
-	class Vest_Base;
+	class Clothing;
 
-	class HighCapacityVest_ColorBase: Vest_Base
+	class HighCapacityVest_ColorBase: Clothing
 	{
 		class DamageSystem
 		{
@@ -37,7 +37,7 @@ class CfgVehicles
 		};
 	};
 
-	class PlateCarrierVest: Vest_Base
+	class PlateCarrierVest: Clothing
 	{
 		class DamageSystem
 		{
@@ -54,7 +54,7 @@ class CfgVehicles
 		};
 	};
 
-	class PressVest_ColorBase: Vest_Base
+	class PressVest_ColorBase: Clothing
 	{
 		class DamageSystem
 		{
@@ -71,7 +71,7 @@ class CfgVehicles
 		};
 	};
 
-	class PoliceVest: Vest_Base
+	class PoliceVest: Clothing
 	{
 		class DamageSystem
 		{

--- a/tweak_weight/config.cpp
+++ b/tweak_weight/config.cpp
@@ -30,41 +30,36 @@ class CfgMagazines
 
 class CfgVehicles
 {
-	class HeadGear_Base;
-	class Top_Base;
-	class Pants_Base;
-	class Mask_Base;
-	class Gloves_Base;
-	class Shoes_Base;
+	class Clothing;
 
 	// ================================================ [ Improvised cloting insulation tweak ] ================================================
 
-	class HeadCover_Improvised: HeadGear_Base
+	class HeadCover_Improvised: Clothing
 	{
 		heatIsolation = 0.3; // improved heat isolation (doubled) from BAD to LOW
 	};
 
-	class TorsoCover_Improvised: Top_Base
+	class TorsoCover_Improvised: Clothing
 	{
 		heatIsolation = 0.3;
 	};
 
-	class LegsCover_Improvised: Pants_Base
+	class LegsCover_Improvised: Clothing
 	{
 		heatIsolation = 0.3;
 	};
 
-	class FaceCover_Improvised: Mask_Base
+	class FaceCover_Improvised: Clothing
 	{
 		heatIsolation = 0.3;
 	};
 
-	class HandsCover_Improvised: Gloves_Base
+	class HandsCover_Improvised: Clothing
 	{
 		heatIsolation = 0.3;
 	};
 
-	class FeetCover_Improvised: Shoes_Base
+	class FeetCover_Improvised: Clothing
 	{
 		heatIsolation = 0.3;
 		class DamageSystem
@@ -96,7 +91,7 @@ class CfgVehicles
 		weight = 900; // 1800
 	};
 
-	class HuntingJacket_ColorBase: Top_Base
+	class HuntingJacket_ColorBase: Clothing
 	{
 		weight = 1650; // 3200
 	};


### PR DESCRIPTION
Reverted the *_base class changes to 'clothing' to work on stable again.